### PR TITLE
Switch Script from Bash to Zsh

### DIFF
--- a/get_pretrained_models.sh
+++ b/get_pretrained_models.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 #
 # For licensing see accompanying LICENSE file.
 # Copyright (C) 2024 Apple Inc. All Rights Reserved.


### PR DESCRIPTION
This pull request updates the get_pretrained_models.sh scripts shebang from **Bash to Zsh** to enhance compatibility with Zsh environments. The functionality remains unchanged, ensuring the script continues to create the checkpoints directory and download the final weights correctly.